### PR TITLE
Fix Ansible 2.8 deprecations in T2L.Java role (used by tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
   include:
     - &Test
 
-      name: Ubuntu 16.04 / Ansible 2.7 / Solr 6.6.6
+      name: Ubuntu 14.04 / Ansible 2.7 / Solr 6.6.6
 
       os: linux
 
@@ -18,7 +18,7 @@ jobs:
 
       python: 3.6
 
-      env: MOLECULE_PLATFORM=ubuntu:16.04 ANSIBLE_VERSION=2.7.* SOLR_VERSION=6.6.6
+      env: MOLECULE_PLATFORM=ubuntu:14.04 ANSIBLE_VERSION=2.7.* SOLR_VERSION=6.6.6
 
       install:
         - pip install ansible==${ANSIBLE_VERSION} docker molecule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Ansible Role: Apache Solr 2.x.x
 
 - [#6](https://github.com/T2L/ansible-role-solr/issues/6) - Added support of Solr 7.5.0+
+- [#7](https://github.com/T2L/ansible-role-solr/issues/7) - Fixed Ansible 2.8 deprecations in T2L.Java role (used by tests)
 
 ## Ansible Role: Apache Solr 2.0.1, 2018-10-26
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -27,6 +27,15 @@
     - ansible-role-solr
 
   vars:
+    # Older Solr versions might not work properly with OpenJDK 11. Let's stick
+    # to the JDK 8.
+    java_openjdk_packages:
+      - version: 8
+        type: jre
+    java_default_alternative:
+      provider: openjdk
+      version: 8
+
     # Do not remove downloads in order to pass idempotence tests.
     solr_cleanup_downloads: false
     solr_cleanup_gpg: false

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: T2L.java
-  version: 1.1.0
+  version: 1.2.0


### PR DESCRIPTION
Closes #9 